### PR TITLE
Fix #17 - Only enable send button when a message is entered

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
                 <div class="input-group ">
           	        <input ng-model="messagesCtrl.message.content" type="text" class="form-control" placeholder="Enter your message">
           	        <span class="input-group-btn">
-          	          <input class="btn btn-default" type="submit" value="Send"></input>
+          	          <input ng-disabled="!messagesCtrl.message.content.length" class="btn btn-default" type="submit" value="Send"></input>
           		    </span>
           		  </div>
               </form>


### PR DESCRIPTION
Think I have it this time.  Much nicer solution as the form can not be submitted without a message present.
